### PR TITLE
CPU boost flag

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -13,7 +13,8 @@ FAIRY COMPUTER SYSTEM 80(FCS80)は、8 ビット時代の技術である Z80 と
 - [3. I/O map](#3-io-map) (I/O マップ)
   - [3-1. $A0~$A2 or $D0~$DF: AY-3-8910](#3-1-a0a2-or-d0df-ay-3-8910) (AY-3-8910: PSG 音源)
   - [3-2. $B0~$B3: Bank switch](#3-2-b0b3-bank-switch) (バンク切り替え)
-  - [3-3. $C0: High Speed DMA (Bank to VRAM)](3-3-c0-high-speed-dma-bank-to-vram) (高速 DMA)
+  - [3-3. $C0: High Speed DMA (Bank to VRAM)](#3-3-c0-high-speed-dma-bank-to-vram) (高速 DMA)
+  - [3-4. $C1: CPU boost flag](#3-4-c1-cpu-boost-flag) (CPU 高速化フラグ)
 - [4. ROM](#4-rom)
   - [4-1. File Format](#4-1-file-format) (ファイル構造)
 - [5. Programming Guide](#5-programming-guide) (プログラミングガイド)
@@ -327,6 +328,10 @@ FCS80 は新規プログラムの作成を容易にする 16 ポートアクセ�
     ld a, $03
     out ($C0), a
 ```
+
+### 3-4. $C1: CPU boost flag
+
+通常、[consumeClock](src/z80.hpp#L340-L346)は 4Hz または 3Hz（GBZ80 の場合は 4Hz に固定）の間隔でコールバックされますが、cpuBoostFlag が 0 でない間は常に 1Hz に固定されることで、CPU の実行速度が 4 ～ 3 倍になります。
 
 ## 4. ROM
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This repository provides an official emulator for the FCS80 core system.
 - [3. I/O map](#3-io-map)
   - [3-1. $A0~$A2 or $D0~$DF: AY-3-8910](#3-1-a0a2-or-d0df-ay-3-8910)
   - [3-2. $B0~$B3: Bank switch](#3-2-b0b3-bank-switch)
-  - [3-3. $C0: High Speed DMA (Bank to VRAM)](3-3-c0-high-speed-dma-bank-to-vram)
+  - [3-3. $C0: High Speed DMA (Bank to VRAM)](#3-3-c0-high-speed-dma-bank-to-vram)
+  - [3-4. $C1: CPU boost flag](#3-4-c1-cpu-boost-flag)
 - [4. ROM](#4-rom)
   - [4-1. File Format](#4-1-file-format)
 - [5. Programming Guide](#5-programming-guide)
@@ -237,6 +238,7 @@ Bit layout:
 |    $B2    |  o  |  o  | PRG2 bank switch (default: $02)                               |
 |    $B3    |  o  |  o  | PRG3 bank switch (default: $03)                               |
 |    $C0    |  -  |  o  | High Speed DMA (ROM to VRAM: Character Pattern Table)         |
+|    $C1    |  o  |  o  | CPU boost flag                                                |
 | $D0 ~ $DF |  o  |  o  | Direct read / write AY-3-8910 registers: #0 ($D0) ~ #15 ($DF) |
 
 ### 3-1. $A0~$A2 or $D0~$DF: AY-3-8910
@@ -327,6 +329,10 @@ The ROM of the bank number corresponding to the value written to the port is tra
     ld a, $03
     out ($C0), a
 ```
+
+### 3-4. $C1: CPU boost flag
+
+Normally, [consumeClock](src/z80.hpp#L340-L346) is called back at an interval of 4Hz or 3Hz (fixed at 4Hz in the case of LR35902), but by always fixing it to 1Hz during cpuBoostFlag is not zero, so the CPU execution speed can be accelerated by 4 to 3 times.
 
 ## 4. ROM
 

--- a/src/fcs80.hpp
+++ b/src/fcs80.hpp
@@ -271,6 +271,7 @@ class FCS80 {
                     addr *= 0x2000;
                     if (addr + 0x2000 <= this->romSize) memcpy(&this->vdp->ctx.ram[0x2000], &this->rom[addr], 0x2000);
                     else memset(&this->vdp->ctx.ram[0x2000], 0xFF, 0x2000);
+                    break;
                 }
                 case 0xC1: this->ctx.cpuBoostFlag = value; break;
                 case 0xD0: this->psg->write(0, value); break;

--- a/src/fcs80.hpp
+++ b/src/fcs80.hpp
@@ -49,6 +49,8 @@ class FCS80 {
             int bobo;
             unsigned char ram[0x4000];
             unsigned char romBank[4];
+            unsigned char cpuBoostFlag;
+            unsigned char reserved[3];
         } ctx;
 
         FCS80() {
@@ -185,6 +187,12 @@ class FCS80 {
 
     private:
         inline void consumeClock(int clocks) {
+            if (this->ctx.cpuBoostFlag) {
+                // Normally, consumeClock is called back at an interval of 4Hz or 3Hz (fixed at 4Hz in the case of GBZ80),
+                // but by always fixing it to 1Hz during cpuBoostFlag is not zero,
+                // so the CPU execution speed can be accelerated by 4 to 3 times.
+                clocks = 1;
+            }
             this->vdp->ctx.bobo += clocks * FCS80_VDP_CLOCK_PER_SEC;
             while (0 < this->vdp->ctx.bobo) {
                 this->vdp->tick();
@@ -229,6 +237,7 @@ class FCS80 {
                 case 0xB1: return this->ctx.romBank[1];
                 case 0xB2: return this->ctx.romBank[2];
                 case 0xB3: return this->ctx.romBank[3];
+                case 0xC1: return this->ctx.cpuBoostFlag;
                 case 0xD0: return this->psg->read(0);
                 case 0xD1: return this->psg->read(1);
                 case 0xD2: return this->psg->read(2);
@@ -263,6 +272,7 @@ class FCS80 {
                     if (addr + 0x2000 <= this->romSize) memcpy(&this->vdp->ctx.ram[0x2000], &this->rom[addr], 0x2000);
                     else memset(&this->vdp->ctx.ram[0x2000], 0xFF, 0x2000);
                 }
+                case 0xC1: this->ctx.cpuBoostFlag = value; break;
                 case 0xD0: this->psg->write(0, value); break;
                 case 0xD1: this->psg->write(1, value); break;
                 case 0xD2: this->psg->write(2, value); break;


### PR DESCRIPTION
CPUを高速化する機能（ポート$C1）を追加

Z80は1ステージ通常4Hz（連続するメモリ空間へのアクセス時は3Hz）で動作するが、$C1に非ゼロをセットすることで、常に1ステージ1Hzで動作するようになることで、3〜4倍程度（約4倍）高速動作するようになる。